### PR TITLE
Use expires instead ends in alert querying by location

### DIFF
--- a/sql/alert_v2_table.go
+++ b/sql/alert_v2_table.go
@@ -166,7 +166,7 @@ func (p *PostgresAlertV2Table) SelectByLocation(codes []string, point geojson_v2
 		LEFT JOIN alertV2_UGCCodes ugc ON a.id = ugc.alertId
 	WHERE 
 	    a.geometry IS NULL AND
-		a.ends >= NOW() AND 
+		a.expires >= NOW() AND 
 		ugc.code = ANY($1::VARCHAR[]);`)
 	if err != nil {
 		return nil, err
@@ -192,7 +192,7 @@ func (p *PostgresAlertV2Table) SelectByLocation(codes []string, point geojson_v2
 	FROM alertV2 a
 	WHERE 
 	    ST_Contains(a.geometry, ST_GeomFromText($1, 4326)) AND
-	    a.ends >= NOW()
+	    a.expires >= NOW()
 	`)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Some alerts don't have an ends time, so we should just always use expires. This could cause us to show alert for longer than the ending time (in an event that an alert gets cancelled), but I think we will want to show users this anyways. 